### PR TITLE
DR2-1441 Tighten Crown Copyright logic.

### DIFF
--- a/src/main/resources/xip-to-bia-v4-functions.xslt
+++ b/src/main/resources/xip-to-bia-v4-functions.xslt
@@ -596,10 +596,10 @@
             <xsl:value-of select="string-join($restrictions, '')"></xsl:value-of>
         </xsl:variable>
         <xsl:choose>
-            <xsl:when test="contains($restrictionsAttributesJoined, 'Crown')">
+            <xsl:when test="lower-case(normalize-space($restrictionsAttributesJoined)) = 'http://datagov.nationalarchives.gov.uk/resource/crown_copyright'">
                 <xsl:value-of select="false()"/>
             </xsl:when>
-            <xsl:when test="contains($restrictionsJoined, 'Crown')">
+            <xsl:when test="lower-case(normalize-space($restrictionsJoined)) = 'crown copyright'">
                 <xsl:value-of select="false()"/>
             </xsl:when>
             <xsl:otherwise>

--- a/src/test/resources/features/crown_copyright.feature
+++ b/src/test/resources/features/crown_copyright.feature
@@ -1,0 +1,19 @@
+Feature: Testing removal of crown copyright from RestrictionOnUse field
+
+  Scenario: When dcterms:right is set to http://datagov.nationalarchives.gov.uk/resource/Crown_copyright
+  RestrictionOnUse element
+    Given I apply XSLT redacted_add_du_for_discovery.xslt on src/test/resources/metadata-ret-related.xml and output {workingDir}/redacted-du.xml and parameters:
+      | parent-id | 101aa1aa-11a1-411a-aaa1-aa1a11a1111a |
+    And I apply XSLT xip-to-bia-v4-a.xslt on {workingDir}/redacted-du.xml and output {workingDir}/bia.xml and parameters:
+      | parent-id            | 101aa1aa-11a1-411a-aaa1-aa1a11a1111a             |
+      | droid-signature-file | ../../test/resources/DROID_SignatureFile_V73.xml |
+      | directories          | ../../test/resources/directories.xml             |
+    Then I want to validate XML {workingDir}/bia.xml with xpath:
+      | xpath                                                                                   | value                                                         |
+      | count(//InformationAsset/RestrictionOnUse)                                              | 3                                                             |
+      | count(//InformationAsset[IAID='aa44b4a3-dd27-4b0a-a6cc-231518c793b3']/RestrictionOnUse) | 0                                                             |
+      | count(//InformationAsset[IAID='c7a9b67d-c8f2-44b2-ade9-5d6dce8d7c77']/RestrictionOnUse) | 0                                                             |
+      | count(//InformationAsset[IAID='aa44b4a3-dd27-4b0a-a6cc-231518c793b3']/RestrictionOnUse) | 0                                                             |
+      | //InformationAsset[IAID='883dc485-4e20-46e0-b79a-57779e7957e0']/RestrictionOnUse        | Copyright: Crown copyright and third party copyright material |
+      | //InformationAsset[IAID='71937a58-8f72-47f4-a6e2-35b7b31c0b8c']/RestrictionOnUse        | Copyright: XML London                                         |
+      | //InformationAsset[IAID='c9ba425e-2806-49d0-8d1a-0898e8435ba5']/RestrictionOnUse        | Copyright: Acme Limited                                       |

--- a/src/test/resources/features/multiple-redactions-related-material.feature
+++ b/src/test/resources/features/multiple-redactions-related-material.feature
@@ -35,7 +35,7 @@ Feature: Related Materials. Records can have redactions and relatedMaterial in t
        | count(//RelatedMaterials)                                                                                        | 4                         |
        | //InformationAsset[IAID = 'c9ba425e-2806-49d0-8d1a-0898e8435ba5']/RelatedMaterials/RelatedMaterial/Description   | FCO 37/AA1                |
        | count(//InformationAsset[IAID = 'c9ba425e-2806-49d0-8d1a-0898e8435ba5']/RelatedMaterials/RelatedMaterial)        | 1                         |
-       | count(//InformationAsset[IAID = 'c9ba425e-2806-49d0-8d1a-0898e8435ba5']/*)                                       | 23                        |
+       | count(//InformationAsset[IAID = 'c9ba425e-2806-49d0-8d1a-0898e8435ba5']/*)                                       | 24                        |
        | //InformationAsset[IAID = '987bf7ed-69e0-4058-ac59-b307ac3bb838']/RelatedMaterials/RelatedMaterial/Description   | FCO 37/6258, FCO 37/6259  |
        | count(//InformationAsset[IAID = '987bf7ed-69e0-4058-ac59-b307ac3bb838']/RelatedMaterials/RelatedMaterial)        | 1                         |
        | count(//InformationAsset[IAID = '987bf7ed-69e0-4058-ac59-b307ac3bb838']/*)                                       | 24                        |
@@ -77,7 +77,7 @@ Feature: Related Materials. Records can have redactions and relatedMaterial in t
       | count(//InformationAsset[IAID = '987bf7ed-69e0-4058-ac59-b307ac3bb838']/*)                                                                                                            | 24          |
       # RelatedMaterials now added to ce9e70828a2a (count +1)
       | count(//InformationAsset[IAID = 'b6581e9f-655a-4205-a673-ce9e70828a2a']/*)                                                                                                            | 24          |
-      | count(//InformationAsset[IAID = 'c9ba425e-2806-49d0-8d1a-0898e8435ba5']/*)                                                                                                            | 23          |
+      | count(//InformationAsset[IAID = 'c9ba425e-2806-49d0-8d1a-0898e8435ba5']/*)                                                                                                            | 24          |
       | count(//InformationAsset[IAID = '987bf7ed-69e0-4058-ac59-b307ac3bb838_2']/RelatedMaterials/RelatedMaterial)                                                                           | 2           |
       | count(//InformationAsset[IAID = '987bf7ed-69e0-4058-ac59-b307ac3bb838_2']/RelatedMaterials/RelatedMaterial/Description[ . = 'This is a redacted record. The full record is retained. To make a Freedom of Information request for the full record contact the creating department.']) | 1 |
       | //InformationAsset[IAID = '987bf7ed-69e0-4058-ac59-b307ac3bb838_2']/RelatedMaterials/RelatedMaterial/IAID        | 987bf7ed-69e0-4058-ac59-b307ac3bb838        |

--- a/src/test/resources/metadata-ret-related.xml
+++ b/src/test/resources/metadata-ret-related.xml
@@ -54,7 +54,7 @@
                            <dcterms:creator xmlns:dcterms="http://purl.org/dc/terms/"
                                             rdf:resource="Foreign_and_Commonwealth_Office"/>
                            <dcterms:rights xmlns:dcterms="http://purl.org/dc/terms/"
-                                           rdf:resource="http://datagov.nationalarchives.gov.uk/resource/Crown_copyright"/>
+                                           rdf:resource="http://datagov.nationalarchives.gov.uk/resource/Crown_copyright_and_third_party_copyright_material"/>
                            <tna:legalStatus rdf:resource="http://datagov.nationalarchives.gov.uk/resource/Public_Record(s)"/>
                            <tna:heldBy rdf:datatype="xs:string">The National Archives, Kew</tna:heldBy>
                            <tna:session_date rdf:datatype="xs:string"/>
@@ -124,7 +124,7 @@
                            <dcterms:creator xmlns:dcterms="http://purl.org/dc/terms/"
                                             rdf:resource="Foreign_and_Commonwealth_Office"/>
                            <dcterms:rights xmlns:dcterms="http://purl.org/dc/terms/"
-                                           rdf:resource="http://datagov.nationalarchives.gov.uk/resource/Crown_copyright"/>
+                                           rdf:resource="http://datagov.nationalarchives.gov.uk/resource/XML_London"/>
                            <tna:legalStatus rdf:resource="http://datagov.nationalarchives.gov.uk/resource/Public_Record(s)"/>
                            <tna:heldBy rdf:datatype="xs:string">The National Archives, Kew</tna:heldBy>
                            <tna:session_date rdf:datatype="xs:string"/>
@@ -268,7 +268,7 @@
                            <dcterms:creator xmlns:dcterms="http://purl.org/dc/terms/"
                                             rdf:resource="Foreign_and_Commonwealth_Office"/>
                            <dcterms:rights xmlns:dcterms="http://purl.org/dc/terms/"
-                                           rdf:resource="http://datagov.nationalarchives.gov.uk/resource/Crown_copyright"/>
+                                           rdf:resource="http://datagov.nationalarchives.gov.uk/resource/XML_London">Crown Copyright</dcterms:rights>
                            <tna:legalStatus rdf:resource="http://datagov.nationalarchives.gov.uk/resource/Public_Record(s)"/>
                            <tna:heldBy rdf:datatype="xs:string">The National Archives, Kew</tna:heldBy>
                            <tna:session_date rdf:datatype="xs:string"/>
@@ -343,7 +343,7 @@
                            <dcterms:creator xmlns:dcterms="http://purl.org/dc/terms/"
                                             rdf:resource="Foreign_and_Commonwealth_Office"/>
                           <dcterms:rights xmlns:dcterms="http://purl.org/dc/terms/"
-                                           rdf:resource="http://datagov.nationalarchives.gov.uk/resource/Crown_copyright"/>
+                                          rdf:resource="http://datagov.nationalarchives.gov.uk/resource/Acme_Limited">Hello Crown World</dcterms:rights>
                            <tna:legalStatus rdf:resource="http://datagov.nationalarchives.gov.uk/resource/Public_Record(s)"/>
                            <tna:heldBy rdf:datatype="xs:string">The National Archives, Kew</tna:heldBy>
                            <tna:relatedMaterial rdf:datatype="xs:string">FCO 37/AA1</tna:relatedMaterial>


### PR DESCRIPTION
This has been changed to check for the full http://datagov.nationalarchives.gov.uk/resource/crown_copyright
text after it has been lower cased.

There are a few checks now based on https://github.com/nationalarchives/dri-xslt-discovery-transfer2/wiki/InformationAsset_RestrictionOnUse_Branch_A

/Crown_copyright - This will not be produced
/XML_London">Hello Crown World -  This will now be produced but wouldn't before
/XML_London">Crown Copyright - This will not be produced
/XML_London - This will be produced.

I've used the existing metadata-ret-related.xml because generating a new
one is really difficult. I had to change one of the existing feature
files because it's producing RestrictionOnUse elements where it wasn't
before.

The second branch in the choose statement which reads:
`<xsl:when test="lower-case(normalize-space($restrictionsJoined)) = 'crown copyright'">`
doesn't ever seem to be called so I've just replaced it with a check for
equality. All the existing tests pass so I think we're ok.
